### PR TITLE
Various CPU instruction fixes

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -758,7 +758,7 @@ impl Cpu {
     fn dma(&mut self) {
         let addr = (self.mem[0xFF46] as MemAddr) << 8;
         
-        for i in 0..0x9A { //number of values to be copied
+        for i in 0..0xA0 { //number of values to be copied
             let val = self.mem[(addr + i) as usize];
             self.mem[(0xFE00 + i) as usize] = val; //start addr + offset
         }
@@ -1681,9 +1681,7 @@ impl Cpu {
     //TODO: Double check (HL) HL thing
     fn jphl(&mut self) {
         let old_pc = self.pc;
-        let hl = self.hl();
-        let n = self.get_mem(hl);
-        let new_pc = add_u16_i8(old_pc, n as i8);
+        let new_pc = self.hl();
 
         if let Some(ref mut logger) = self.event_logger {
             logger.log_jump(self.cycles, old_pc, new_pc);

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1589,12 +1589,12 @@ impl Cpu {
                        old_bit0 == 1);
     }
 
+    /// Rotate n right through Carry flag.
     fn rr(&mut self, reg: CpuRegister) {
         let reg_val = self.access_register(reg).expect("invalid register");
         let old_bit0 = reg_val & 1;
-        let old_flags = ((self.f & CL) >> 4) & 0xF;
+        let old_flags = (self.f & CL) << 3;
 
-        //todo: wat
         let new_val = (reg_val >> 1) | old_flags;
         self.set_register(reg, new_val);
 

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -856,7 +856,8 @@ impl Cpu {
 
     fn set_af(&mut self, v:u16) {
         self.a = ((v >> 8) & 0xFF) as byte;
-        self.f = (v & 0xFF) as byte;
+        // lower 4 bits are always zero
+        self.f = (v & 0xF0) as byte;
     }
 
     fn hl(&self) -> u16 {

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1762,8 +1762,9 @@ impl Cpu {
 
     fn rst(&mut self, n: u8) {
         let old_pc = self.pc;
-        
-        self.push_onto_stack(old_pc);
+
+        // Should store PC post-increment for RET from handler to work
+        self.push_onto_stack(old_pc.wrapping_add(1));
 
         self.pc = n as u16;
     }

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1144,7 +1144,10 @@ impl Cpu {
 
     fn ldnnsp(&mut self, b1: u8, b2: u8) {
         let old_sp = self.sp;
-        self.set_mem((((b2 as u16) << 8) | (b1 as u16)), old_sp as byte);
+        let addr = byte_to_u16(b1, b2);
+        // TODO function to write word (16 bit) to memory
+        self.set_mem(addr, old_sp as byte & 0xFFu8);
+        self.set_mem(addr.wrapping_add(1), ((old_sp >> 8) as byte & 0xFFu8) as byte);
     }
 
     // fn pushnn(&mut self, nn: CpuRegister16) {

--- a/src/io/vidram.rs
+++ b/src/io/vidram.rs
@@ -30,7 +30,7 @@ impl Drawable for VidRamBGDisplay {
 
         let tile_patterns_offset = match *bg_select {
             TileDataSelect::Auto => {
-                if cpu.lcdc_bg_tile_map() {
+                if cpu.lcdc_bg_win_tile_data() {
                     TILE_PATTERN_TABLE_1_ORIGIN
                 } else {
                     TILE_PATTERN_TABLE_2_ORIGIN


### PR DESCRIPTION
I suppose "JP (HL)" has confusing mnemonic... Now
`cpu_instrs/individual/*` tests actually show useful info.