### PR TITLE
Add Gameboy color support + misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "gameboy-rom"
-version = "0.2.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96370e39411f402bb1bc6b39cf3200c8c931884a8c7ce9aeb4d38d80ccfa935"
+checksum = "301133411143a7c939a82477d6f435483c8836b395fb18192ba846d8fa3fcc53"
 dependencies = [
  "nom 5.0.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ development = ["debugger"]
 [dependencies]
 app_dirs = "^1.1.1"
 clap = "^2.31"
-gameboy-rom = "0.2"
+gameboy-rom = { version = "0.4" }
 lazy_static = "^1.0"
-log = { version = "0.4", features = ["max_level_info", "release_max_level_info"] }
+log = { version = "0.4", features = ["max_level_info", "release_max_level_debug"] }
 log4rs = "1.2"
 rand = "^0.8.5"
 sdl2 = "^0.35.2"

--- a/src/cpu/memory.rs
+++ b/src/cpu/memory.rs
@@ -26,6 +26,12 @@ pub struct Memory {
 
     pub gbc_wram_bank: u8,
 
+    // extra GBC ram, accessed via 0xFF68 and 0xFF69
+    // TODO: locked during mode 3
+    pub gbc_background_color_palette: [byte; 0x40],
+
+    pub gbc_sprite_color_palette: [byte; 0x40],
+
     /// unusable values
     /// 0xFEA0-0xFF00
     empty: [byte; 0x6F],
@@ -73,6 +79,8 @@ impl Memory {
             // default to 1 so normal gameboy works as expected
             gbc_wram_bank: 1,
             gbc_vram_bank: 0,
+            gbc_background_color_palette: [0xFF; 0x40],
+            gbc_sprite_color_palette: [0xFF; 0x40],
         }
     }
 
@@ -112,7 +120,7 @@ impl Memory {
     }
 
     pub fn set_gbc_mode(&mut self) {
-        self.gbc_wram_bank = 0;
+        self.gbc_wram_bank = 1;
     }
 
     pub fn initialize_logger(&mut self) {
@@ -178,6 +186,9 @@ impl Memory {
         self[0xFF4A] = 0x00;
         self[0xFF4B] = 0x00;
         self[0xFFFF] = 0x00;
+
+        self.gbc_background_color_palette = [0xFF; 0x40];
+        self.gbc_sprite_color_palette = [0xFF; 0x40];
     }
 }
 

--- a/src/io/dr_sdl2.rs
+++ b/src/io/dr_sdl2.rs
@@ -94,7 +94,7 @@ impl Sdl2Renderer {
 }
 
 impl Renderer for Sdl2Renderer {
-    fn draw_frame(&mut self, frame: &[[u8; GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]) {
+    fn draw_frame(&mut self, frame: &[[(u8, u8, u8); GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]) {
         let scale = 3.0;
         //app_settings.ui_scale;
         match self.canvas.set_scale(scale, scale) {
@@ -117,8 +117,7 @@ impl Renderer for Sdl2Renderer {
 
         for y in 0..GB_SCREEN_HEIGHT {
             for x in 0..GB_SCREEN_WIDTH {
-                let px_color = frame[y][x];
-                let (r, g, b) = TILE_PALETTE[px_color as usize].rgb();
+                let (r, g, b) = frame[y][x];
                 let color = sdl2::pixels::Color::RGB(r, g, b);
 
                 temp_canvas.set_draw_color(color);

--- a/src/io/graphics/renderer.rs
+++ b/src/io/graphics/renderer.rs
@@ -9,7 +9,7 @@ pub enum EventResponse {
 }
 
 pub trait Renderer {
-    fn draw_frame(&mut self, frame: &[[u8; GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]);
+    fn draw_frame(&mut self, frame: &[[(u8, u8, u8); GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]);
     fn draw_gameboy(&mut self, _: &mut Cpu, _: &ApplicationSettings) -> usize;
     fn draw_memory_visualization(&mut self, _: &Cpu, _: &ApplicationSettings);
     fn handle_events(&mut self, _: &mut Cpu, _: &ApplicationSettings) -> Vec<EventResponse>;

--- a/src/io/graphics/sdl2/mod.rs
+++ b/src/io/graphics/sdl2/mod.rs
@@ -158,7 +158,7 @@ impl Sdl2Renderer {
 }
 
 impl Renderer for Sdl2Renderer {
-    fn draw_frame(&mut self, _frame: &[[u8; GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]) {
+    fn draw_frame(&mut self, _frame: &[[(u8, u8, u8); GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]) {
         todo!("do this later if we care")
     }
 


### PR DESCRIPTION
Passes cgb-acid2 except for 1 small issue. Other color roms on MBC5 were working but after changing something related to that it stopped working. I couldn't figure out what exactly it is but MBC1 color roms seem almost perfect so it's likely the cartridge logic