### PR TITLE
Port emulator to Wasm + add support code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,27 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -37,12 +52,9 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atty"
@@ -52,14 +64,8 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
-
-[[package]]
-name = "autocfg"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 
 [[package]]
 name = "autocfg"
@@ -74,16 +80,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cc"
-version = "1.0.37"
+name = "bumpalo"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.9"
+name = "cc"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -93,14 +99,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.7"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
- "libc",
- "num-integer",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
  "time",
+ "wasm-bindgen",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -117,6 +126,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "derivative"
@@ -136,16 +151,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
-name = "dtoa"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-
-[[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "gameboy"
@@ -154,16 +163,12 @@ dependencies = [
  "app_dirs",
  "clap",
  "gameboy-rom",
- "lazy_static",
  "log",
  "log4rs",
  "ncurses",
  "nom 2.2.1",
  "rand",
  "sdl2",
- "serde",
- "serde_derive",
- "time",
 ]
 
 [[package]]
@@ -172,7 +177,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301133411143a7c939a82477d6f435483c8836b395fb18192ba846d8fa3fcc53"
 dependencies = [
- "nom 5.0.0",
+ "nom 5.1.3",
  "serde",
 ]
 
@@ -182,10 +187,16 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -212,10 +223,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "itoa"
-version = "0.4.4"
+name = "iana-time-zone"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -225,14 +278,14 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical-core"
-version = "0.4.8"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34449d00c5d4066537f4dc72320b18e3aa421e8e92669250eecd664c618fefce"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
- "cfg-if 0.1.9",
- "rustc_version",
- "ryu 1.0.13",
+ "bitflags",
+ "cfg-if",
+ "ryu",
  "static_assertions",
 ]
 
@@ -244,9 +297,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -254,17 +307,16 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 dependencies = [
- "cfg-if 0.1.9",
  "serde",
 ]
 
@@ -297,31 +349,25 @@ dependencies = [
  "thiserror",
  "thread-id",
  "typemap-ors",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "ncurses"
-version = "5.99.0"
+version = "5.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15699bee2f37e9f8828c7b35b2bc70d13846db453f2d507713b758fabe536b82"
+checksum = "5e2c5d34d72657dc4b638a1c25d40aae81e4f1c699062f72f467237920752032"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -331,9 +377,9 @@ checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 
 [[package]]
 name = "nom"
-version = "5.0.0"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9761d859320e381010a4f7f8ed425f2c924de33ad121ace447367c713ad561b"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
 dependencies = [
  "lexical-core",
  "memchr",
@@ -341,22 +387,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
-dependencies = [
- "autocfg 0.1.4",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
-version = "0.2.8"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 0.1.4",
+ "autocfg",
 ]
 
 [[package]]
@@ -368,6 +404,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "ordered-float"
@@ -394,7 +436,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
@@ -403,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.14"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -463,12 +505,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
@@ -486,25 +522,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
-version = "0.2.8"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
-
-[[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "scopeguard"
@@ -530,31 +551,16 @@ version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3586be2cf6c0a8099a79a12b4084357aa9b3e0b0d7980e3b67aaf7a9d55f9f0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "version-compare",
 ]
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
 ]
@@ -571,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -582,23 +588,23 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.39"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
- "ryu 0.2.8",
+ "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.9"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "dtoa",
- "linked-hash-map",
+ "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]
@@ -615,15 +621,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "static_assertions"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -664,18 +670,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -690,18 +696,18 @@ checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
 dependencies = [
  "libc",
  "redox_syscall 0.2.16",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
- "redox_syscall 0.1.54",
- "winapi 0.3.7",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -715,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-width"
@@ -748,15 +754,75 @@ checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "winapi"
@@ -766,9 +832,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -791,6 +857,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -869,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,36 +5,39 @@ edition = "2021"
 authors = ["MarkMcCaskey <rabidwaffle@gmail.com>"]
 description = "A Gameboy emulator and related tools"
 
+[lib]
+name = "rusty_boy_lib"
+crate-type = ["cdylib"]
+path = "src/lib.rs"
+
 [badges]
 travis-ci = { repository = "MarkMcCaskey/rusty-boy", branch = "master" }
 maintainence = {status = "experimental"}
 
 [features]
-default = []
+default = ["cli"]
 asm = ["nom"]
 debugger = ["ncurses", "nom"]
 vulkan = []
 development = ["debugger"]
+cli = ["clap", "log4rs", "desktop"]
+desktop = ["app_dirs", "sdl2"]
 
 [dependencies]
-app_dirs = "^1.1.1"
-clap = "^2.31"
+app_dirs = { version = "^1.1.1", optional = true }
+clap = { version = "^2.31", optional = true}
 gameboy-rom = { version = "0.4" }
-lazy_static = "^1.0"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
-log4rs = "1.2"
-rand = "^0.8.5"
-sdl2 = "^0.35.2"
-serde = "^1.0.0"
-serde_derive = "^1.0.0"
-time = "^0.1"
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
+log4rs = { version = "1.2", optional = true }
+rand = { version = "^0.8.5", optional = true }
+sdl2 = { version = "^0.35.2", optional = true }
 
 #vulkano = {version = "0.6.2", optional = true}
 #vulkano-shader-derive = {version = "0.6.2", optional = true}
 #winit = {version = "0.7.6", optional = true}
 #vulkano-win = {version = "0.6.2", optional = true}
 
-nom = {version = "^2.2", optional = true}
+nom = { version = "^2.2", optional = true }
 ncurses = {version = "^5.85.0", optional = true}
 
 [profile.dev]
@@ -52,5 +55,5 @@ debug = false
 rpath = false
 lto = true
 debug-assertions = false
-# codegen-units = 1
+codegen-units = 1
 panic = 'unwind'

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cargo build --release --target=wasm32-unknown-unknown --no-default-features --lib
+wasm-opt -O target/wasm32-unknown-unknown/release/rusty_boy_lib.wasm -o target/wasm32-unknown-unknown/release/opt.wasm
+wasm-strip target/wasm32-unknown-unknown/release/opt.wasm -o target/wasm32-unknown-unknown/release/opt.wasm

--- a/src/cpu/cartridge/mod.rs
+++ b/src/cpu/cartridge/mod.rs
@@ -7,7 +7,7 @@ use crate::cpu::constants::*;
 
 /// A thing that is like a Cartridge
 pub trait Cartridgey {
-    fn load(rom_file: &str) -> Result<Cartridge, String>;
+    fn load(rom_data: Vec<u8>) -> Result<Cartridge, String>;
 
     fn read_rom_value(&self, index: u16) -> byte;
 
@@ -41,15 +41,7 @@ pub struct Cartridge {
 }
 
 impl Cartridgey for Cartridge {
-    fn load(file_path: &str) -> Result<Cartridge, String> {
-        use std::fs::File;
-        use std::io::Read;
-
-        let mut rom =
-            File::open(file_path).map_err(|e| format!("Could not open ROM file: {}", e))?;
-        let mut rom_buffer = Vec::with_capacity(0x4000);
-        rom.read_to_end(&mut rom_buffer)
-            .map_err(|e| format!("Could not read ROM data from file: {}", e))?;
+    fn load(rom_buffer: Vec<u8>) -> Result<Cartridge, String> {
         let rom = gameboy_rom::GameBoyRom::new(rom_buffer.as_slice());
         let rom_header = rom.parse_header()?;
 

--- a/src/cpu/memory.rs
+++ b/src/cpu/memory.rs
@@ -75,7 +75,7 @@ impl Memory {
             hram: [0u8; 0x80],
             interrupt_flag: 0,
             iterator_index: 0,
-            logger: Some(DeqCpuEventLogger::new(None)),
+            logger: None, //Some(DeqCpuEventLogger::new(None)),
             // default to 1 so normal gameboy works as expected
             gbc_wram_bank: 1,
             gbc_vram_bank: 0,
@@ -91,8 +91,8 @@ impl Memory {
         }
     }
 
-    pub fn load(&mut self, input_file: &str) {
-        *self.cartridge = Cartridge::load(input_file).expect("Could not load ROM");
+    pub fn load(&mut self, rom_bytes: Vec<u8>) {
+        *self.cartridge = Cartridge::load(rom_bytes).expect("Could not load ROM");
     }
 
     pub fn load_saved_ram(&mut self, mut path: PathBuf, game_name: &str) {

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1992,31 +1992,32 @@ impl Cpu {
 
         let old_pc = self.pc;
 
-        //Then execute instruction
-        let (inst_name, inst_len) = pp_opcode(first_byte, second_byte, third_byte, self.pc);
-        let next_pc = (Wrapping(old_pc) + Wrapping(inst_len as u16)).0;
-        match inst_len {
-            1 => {
-                trace!(
-                    "Running {:02x}    :  -> 0x{:04X}: {:<20}",
-                    first_byte,
-                    self.pc,
-                    inst_name
-                )
-            }
-            2 => {
-                trace!(
-                    "Running {:02x}{:02x}  :  -> 0x{:04X}: {:<20} 0x{:02X}  ; next 0x{:04X}",
-                    first_byte,
-                    second_byte,
-                    self.pc,
-                    inst_name,
-                    second_byte,
-                    next_pc
-                )
-            }
-            3 => {
-                trace!("Running {:02x}{:02x}{:02x}:  -> 0x{:04X}: {:<20} 0x{:02X} 0x{:02X}  ; next 0x{:04X}",
+        if log::log_enabled!(log::Level::Trace) {
+            //Then execute instruction
+            let (inst_name, inst_len) = pp_opcode(first_byte, second_byte, third_byte, self.pc);
+            let next_pc = (Wrapping(old_pc) + Wrapping(inst_len as u16)).0;
+            match inst_len {
+                1 => {
+                    trace!(
+                        "Running {:02x}    :  -> 0x{:04X}: {:<20}",
+                        first_byte,
+                        self.pc,
+                        inst_name
+                    )
+                }
+                2 => {
+                    trace!(
+                        "Running {:02x}{:02x}  :  -> 0x{:04X}: {:<20} 0x{:02X}  ; next 0x{:04X}",
+                        first_byte,
+                        second_byte,
+                        self.pc,
+                        inst_name,
+                        second_byte,
+                        next_pc
+                    )
+                }
+                3 => {
+                    trace!("Running {:02x}{:02x}{:02x}:  -> 0x{:04X}: {:<20} 0x{:02X} 0x{:02X}  ; next 0x{:04X}",
                        first_byte,
                        second_byte,
                        third_byte,
@@ -2025,8 +2026,9 @@ impl Cpu {
                        second_byte,
                        third_byte,
                        next_pc)
+                }
+                n => error!("Instruction with impossible length: {:?}", n),
             }
-            n => error!("Instruction with impossible length: {:?}", n),
         }
 
         let uf = "The impossible happened!";
@@ -2410,9 +2412,9 @@ impl Cpu {
     }
 
     /// Loads the ROM with saved RAM if its available
-    pub fn load_rom(&mut self, file_path: &str, data_path: Option<PathBuf>) {
+    pub fn load_rom(&mut self, rom_bytes: Vec<u8> /*, data_path: Option<PathBuf>*/) {
         trace!("Loading ROM");
-        self.mem.load(file_path);
+        self.mem.load(rom_bytes);
         self.gbc_mode = self.mem.gbc_mode();
         if self.gbc_mode {
             self.mem.set_gbc_mode();
@@ -2420,13 +2422,18 @@ impl Cpu {
         self.sgb_mode = self.mem.gbc_mode();
         self.reset();
 
+        // TODO: revisit where this code should live when properly implementing
+        // resuming from saves / savestates.
+        /*
         // load RAM if it exists
         if let Some(data_location) = data_path {
             let game_name = self.get_game_name();
             self.mem.load_saved_ram(data_location, game_name.as_ref());
         }
+        */
 
-        self.mem.initialize_logger();
+        // disable for now
+        //self.mem.initialize_logger();
     }
 
     pub fn save_ram(&self, data_path: Option<PathBuf>) {

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -1,7 +1,5 @@
 // Code courtesy of spawnedartifact
 
-extern crate clap;
-
 use std::num::Wrapping;
 
 #[allow(unknown_lints)]
@@ -289,6 +287,7 @@ pub fn disasm_rom_to_vec(rom: [u8; 0x8000], rom_size: usize) -> Vec<(String, u16
     ret
 }
 
+#[cfg(cli)]
 #[allow(dead_code)]
 fn main() {
     // // Print "[prefix] opcode size mnemonic" table

--- a/src/io/applicationsettings.rs
+++ b/src/io/applicationsettings.rs
@@ -1,6 +1,6 @@
 //! Stores all settings related to the application from a user perspective
 
-use crate::io::constants::{APP_INFO, SCALE};
+use crate::io::constants::SCALE;
 use app_dirs::*;
 use clap::ArgMatches;
 use std::path::PathBuf;
@@ -11,7 +11,12 @@ use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+pub const APP_INFO: AppInfo = AppInfo {
+    name: "rusty-boy",
+    author: "Mark McCaskey, SpawnedArtifact, and friends",
+};
+
+#[derive(Debug, Clone)]
 pub struct ApplicationSettings {
     pub rom_file_name: String,
     pub debug_mode: bool,
@@ -19,7 +24,7 @@ pub struct ApplicationSettings {
     pub memvis_mode: bool,
     pub debugger_on: bool,
     pub vulkan_mode: bool,
-    config_path: Option<PathBuf>,
+    _config_path: Option<PathBuf>,
     pub data_path: Option<PathBuf>,
     pub ui_scale: f32,
 }
@@ -91,7 +96,7 @@ impl ApplicationSettings {
             trace_mode,
             memvis_mode,
             vulkan_mode,
-            config_path,
+            _config_path: config_path,
             data_path,
             debugger_on: should_debugger,
             //               logger_handle: handle,

--- a/src/io/constants.rs
+++ b/src/io/constants.rs
@@ -1,7 +1,4 @@
 use crate::cpu::constants::*;
-use app_dirs::AppInfo;
-use sdl2;
-use sdl2::pixels::*;
 
 pub const RB_SCREEN_WIDTH: u32 = 1400;
 pub const RB_SCREEN_HEIGHT: u32 = 900;
@@ -62,63 +59,39 @@ pub const TILE_SIZE_PX: u16 = 8;
 pub const BORDER_PX: u16 = 1;
 pub const TILE_COLUMNS: u16 = 16;
 
-lazy_static! {
-    pub static ref TILE_PALETTE: [Color; 4] = [
-        /*Color::RGB(255, 255, 255),
-        Color::RGB(0xB5, 0xB5, 0xB5),
-        Color::RGB(0x4D, 0x4D, 0x4D),
-        Color::RGB(0, 0, 0)*/
-        /*
-        Color::RGB(4, 5, 7),
-        Color::RGB(235, 135, 140),
-        Color::RGB(156, 146, 244),
-        Color::RGB(252, 250, 175)
-        */
+pub static TILE_PALETTE: [(u8, u8, u8); 4] = [
+    // Accurate colors for DMG:
 
-        // Accurate colors for DMG:
+    // Darkest Green
+    // Hex: #0f380f
+    (15, 56, 15),
+    // Dark Green
+    // Hex: #306230
+    (48, 98, 48),
+    // Light Green
+    // Hex: #8bac0f
+    (139, 172, 15),
+    // Lightest Green
+    // Hex: #9bbc0f
+    (155, 188, 15),
+];
+pub static OBJECT_PALETTE: [(u8, u8, u8); 4] = [
+    // Accurate colors for DMG:
 
-        // Darkest Green
-        // Hex: #0f380f
-        Color::RGB(15, 56, 15),
-        // Dark Green
-        // Hex: #306230
-        Color::RGB(48, 98, 48),
-        // Light Green
-        // Hex: #8bac0f
-        Color::RGB(139, 172, 15),
-        // Lightest Green
-        // Hex: #9bbc0f
-        Color::RGB(155, 188, 15),
-    ];
-    pub static ref OBJECT_PALETTE: [Color; 4] = [
-        /*Color::RGB(255, 255, 255),
-        Color::RGB(0xB5, 0xB5, 0xB5),
-        Color::RGB(0x4D, 0x4D, 0x4D),
-        Color::RGB(0, 0, 0)*/
-        /*
-        Color::RGB(0, 0, 0),
-        Color::RGB(174, 124, 9),
-        Color::RGB(248, 184, 0),
-        Color::RGB(248, 240, 240)
-        */
-
-        // Accurate colors for DMG:
-
-        // Darkest Green
-        // Hex: #0f380f
-        Color::RGB(15, 56, 15),
-        // Dark Green
-        // Hex: #306230
-        Color::RGB(48, 98, 48),
-        // Light Green
-        // Hex: #8bac0f
-        Color::RGB(139, 172, 15),
-        // Lightest Green
-        // Hex: #9bbc0f
-        Color::RGB(155, 188, 15),
-    ];
-    pub static ref NICER_COLOR: sdl2::pixels::Color = sdl2::pixels::Color::RGBA(139, 41, 2, 255);
-}
+    // Darkest Green
+    // Hex: #0f380f
+    (15, 56, 15),
+    // Dark Green
+    // Hex: #306230
+    (48, 98, 48),
+    // Light Green
+    // Hex: #8bac0f
+    (139, 172, 15),
+    // Lightest Green
+    // Hex: #9bbc0f
+    (155, 188, 15),
+];
+pub static NICER_COLOR: (u8, u8, u8, u8) = (139, 41, 2, 255);
 
 pub const SCREEN_BUFFER_SIZE_X: u32 = 256;
 pub const SCREEN_BUFFER_SIZE_Y: u32 = 256;
@@ -132,8 +105,3 @@ pub const GB_SCREEN_HEIGHT: usize = 144;
 pub const OBJECT_ATTRIBUTE_START: u16 = 0xFE00;
 pub const OBJECT_ATTRIBUTE_END: u16 = 0xFE9F;
 pub const OBJECT_ATTRIBUTE_BLOCK_SIZE: u16 = 4;
-
-pub const APP_INFO: AppInfo = AppInfo {
-    name: "rusty-boy",
-    author: "Mark McCaskey, SpawnedArtifact, and friends",
-};

--- a/src/io/deferred_renderer.rs
+++ b/src/io/deferred_renderer.rs
@@ -145,7 +145,7 @@ pub fn deferred_renderer_draw_scanline(
                 bg_pixels[x] = colors[px_color as usize];
                 gbc_bg_override = gbc_bg_override || bg_priority;
             } else {
-                bg_pixels[x] = bg_colors[px_color as usize].rgb();
+                bg_pixels[x] = bg_colors[px_color as usize];
             }
             bg_opacities[x] = bg_opacities[x] || (px_color != 0);
 
@@ -223,7 +223,7 @@ pub fn deferred_renderer_draw_scanline(
                     bg_pixels[x] = colors[px_color as usize];
                     gbc_bg_override = gbc_bg_override || bg_priority;
                 } else {
-                    bg_pixels[x] = bg_colors[px_color as usize].rgb();
+                    bg_pixels[x] = bg_colors[px_color as usize];
                 }
                 bg_opacities[x] = bg_opacities[x] || (px_color != 0);
 
@@ -341,7 +341,7 @@ pub fn deferred_renderer_draw_scanline(
                         ];
                         bg_pixels[x] = colors[px_color as usize];
                     } else {
-                        bg_pixels[x] = true_color.rgb();
+                        bg_pixels[x] = true_color;
                     }
                     // highest priority pixel value found here, we shouldn't draw anything else
                     break;

--- a/src/io/graphics/mod.rs
+++ b/src/io/graphics/mod.rs
@@ -1,6 +1,7 @@
 pub mod renderer;
+#[cfg(feature = "desktop")]
 pub mod sdl2;
-#[cfg(feature = "vulkan")]
+#[cfg(all(feature = "vulkan", feature = "desktop"))]
 pub mod vulkan;
 
 /*

--- a/src/io/graphics/renderer.rs
+++ b/src/io/graphics/renderer.rs
@@ -1,5 +1,4 @@
 use crate::cpu::Cpu;
-use crate::io::applicationsettings::ApplicationSettings;
 use crate::io::constants::{GB_SCREEN_HEIGHT, GB_SCREEN_WIDTH};
 
 #[derive(Debug, Copy, Clone)]
@@ -10,7 +9,9 @@ pub enum EventResponse {
 
 pub trait Renderer {
     fn draw_frame(&mut self, frame: &[[(u8, u8, u8); GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]);
-    fn draw_gameboy(&mut self, _: &mut Cpu, _: &ApplicationSettings) -> usize;
-    fn draw_memory_visualization(&mut self, _: &Cpu, _: &ApplicationSettings);
-    fn handle_events(&mut self, _: &mut Cpu, _: &ApplicationSettings) -> Vec<EventResponse>;
+    // TOOD: readd important data to args here later
+    fn draw_memory_visualization(&mut self, _: &Cpu) {
+        unimplemented!();
+    }
+    fn handle_events(&mut self, _: &mut Cpu) -> Vec<EventResponse>;
 }

--- a/src/io/graphics/sdl2/vidram.rs
+++ b/src/io/graphics/sdl2/vidram.rs
@@ -125,7 +125,7 @@ pub fn draw_tile(
             let col_bit_2 = get_bit(col_byte2_v, px as u8);
             let px_color = (col_bit_2 << 1) | col_bit_1;
 
-            let (rval, gval, bval) = TILE_PALETTE[px_color as usize].rgb();
+            let (rval, gval, bval) = TILE_PALETTE[px_color as usize];
 
             let tile_index = ((py * TILE_SIZE_PX) + (px)) * 4;
             // TODO: verify this order is correct outside of Linux...
@@ -201,7 +201,7 @@ pub fn draw_tile_transparent<T>(
             }*/
 
             //if DEBUG_OAM_BG || px_color != 0 {
-            let (rval, bval, gval) = OBJECT_PALETTE[px_color as usize].rgb();
+            let (rval, bval, gval) = OBJECT_PALETTE[px_color as usize];
             let tile_index = ((((realpy as u16) * TILE_SIZE_PX) + (realpx as u16)) * 4) as u8;
             pixel_buffer[tile_index.wrapping_add(0) as usize] = if px_color == 0 { 0 } else { 255 };
             pixel_buffer[(tile_index.wrapping_add(1)) as usize] = gval;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,11 +1,15 @@
 //! IO related functions
 
+#[cfg(feature = "desktop")]
 pub mod applicationsettings;
 pub mod applicationstate;
+#[cfg(feature = "cli")]
 pub mod arguments;
 pub mod constants;
 pub mod deferred_renderer;
+#[cfg(feature = "desktop")]
 pub mod dr_sdl2;
 pub mod events;
 pub mod graphics;
+#[cfg(feature = "desktop")]
 pub mod sound;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,183 @@
+#![cfg(not(feature = "desktop"))]
+
+//! This is the entrypoint for the library version of the emulator.
+//!
+//! This is mostly useful for creating a standalone wasm32-unknown-unknown
+//! version of the emulator that can run in a browser. However it could also
+//! be used to create a native library that can be linked to from other
+//! code if desired.
+
+#[macro_use]
+extern crate log;
+
+pub mod cpu;
+/// Naive disassembler
+pub mod disasm;
+pub mod io;
+
+use crate::io::applicationstate::*;
+use crate::io::constants::{GB_SCREEN_HEIGHT, GB_SCREEN_WIDTH};
+use crate::io::graphics::renderer::Renderer;
+
+extern "C" {
+    /// A pointer pointing to exactly 160x144x3 bytes of memory.
+    /// RGB values are stored in order, top to bottom, left to right.
+    fn draw_frame(frame: *const u8);
+    // TODO: figure out what kind of data we need for audio
+    //fn output_audio(audio_buffer: &[i16]);
+    fn info_message(message: *const u8, length: usize);
+    fn error_message(message: *const u8, length: usize);
+    fn warn_message(message: *const u8, length: usize);
+    fn debug_message(message: *const u8, length: usize);
+    fn trace_message(message: *const u8, length: usize);
+}
+
+const LOGGER: ExternalLogger = ExternalLogger;
+
+// TODO: change up the way ROM data is passed in
+// TODO: add params to specify settings
+#[no_mangle]
+pub extern "C" fn create_emulator() -> Option<Box<ApplicationState>> {
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(log::LevelFilter::Info))
+        .unwrap();
+    let external_renderer = ExternalRenderer;
+    let application_state = match ApplicationState::new(Box::new(external_renderer)) {
+        Ok(apst) => apst,
+        Err(e) => {
+            error!("Fatal error: could not create Gameboy: {}", e);
+            return None;
+        }
+    };
+    Some(Box::new(application_state))
+}
+
+#[no_mangle]
+pub extern "C" fn destroy_emulator(_application_state: Option<Box<ApplicationState>>) {}
+
+#[no_mangle]
+pub extern "C" fn step(application_state: &mut ApplicationState) {
+    // TODO: handle events
+    application_state.step();
+}
+
+#[repr(C)]
+pub enum ButtonInput {
+    A = 0,
+    B = 1,
+    Start = 2,
+    Select = 3,
+    Up = 4,
+    Down = 5,
+    Left = 6,
+    Right = 7,
+}
+
+#[no_mangle]
+pub extern "C" fn press_button(
+    application_state: &mut ApplicationState,
+    button: ButtonInput,
+    pressed: bool,
+) {
+    match (button, pressed) {
+        (ButtonInput::A, true) => application_state.gameboy.press_a(),
+        (ButtonInput::A, false) => application_state.gameboy.unpress_a(),
+        (ButtonInput::B, true) => application_state.gameboy.press_b(),
+        (ButtonInput::B, false) => application_state.gameboy.unpress_b(),
+        (ButtonInput::Start, true) => application_state.gameboy.press_start(),
+        (ButtonInput::Start, false) => application_state.gameboy.unpress_start(),
+        (ButtonInput::Select, true) => application_state.gameboy.press_select(),
+        (ButtonInput::Select, false) => application_state.gameboy.unpress_select(),
+        (ButtonInput::Up, true) => application_state.gameboy.press_up(),
+        (ButtonInput::Up, false) => application_state.gameboy.unpress_up(),
+        (ButtonInput::Down, true) => application_state.gameboy.press_down(),
+        (ButtonInput::Down, false) => application_state.gameboy.unpress_down(),
+        (ButtonInput::Left, true) => application_state.gameboy.press_left(),
+        (ButtonInput::Left, false) => application_state.gameboy.unpress_left(),
+        (ButtonInput::Right, true) => application_state.gameboy.press_right(),
+        (ButtonInput::Right, false) => application_state.gameboy.unpress_right(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn reset(application_state: &mut ApplicationState) {
+    application_state.gameboy.reset();
+}
+
+/// Load a new ROM into the emulator.
+///
+/// # Safety
+/// Rom_data_ptr must point to a valid slice of memory that is at least rom_data_len bytes long.
+#[no_mangle]
+pub unsafe extern "C" fn load_rom(
+    application_state: &mut ApplicationState,
+    rom_data_ptr: *const u8,
+    rom_data_len: usize,
+) {
+    let rom_data = std::slice::from_raw_parts(rom_data_ptr, rom_data_len).to_owned();
+    application_state.gameboy.load_rom(rom_data);
+}
+
+#[repr(C)]
+pub struct ExternalRenderer;
+
+impl Renderer for ExternalRenderer {
+    fn draw_frame(&mut self, frame: &[[(u8, u8, u8); GB_SCREEN_WIDTH]; GB_SCREEN_HEIGHT]) {
+        let buffer = frame
+            .iter()
+            .flat_map(|row| row.iter().flat_map(|(r, g, b)| vec![*r, *g, *b]))
+            .collect::<Vec<u8>>();
+        unsafe {
+            draw_frame(buffer.as_ptr());
+        }
+    }
+
+    fn handle_events(
+        &mut self,
+        _: &mut crate::cpu::Cpu,
+    ) -> Vec<crate::io::graphics::renderer::EventResponse> {
+        // there is no need to do anything here
+        // TODO: look into restructing the code so this trait isn't required
+        vec![]
+    }
+}
+
+use log::{Level, Metadata, Record};
+
+struct ExternalLogger;
+
+impl log::Log for ExternalLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let message = format!("{}", record.args());
+            let bytes = message.as_bytes();
+            match record.level() {
+                Level::Error => unsafe { error_message(bytes.as_ptr(), bytes.len()) },
+                Level::Warn => unsafe { warn_message(bytes.as_ptr(), bytes.len()) },
+                Level::Info => unsafe { info_message(bytes.as_ptr(), bytes.len()) },
+                Level::Debug => unsafe { debug_message(bytes.as_ptr(), bytes.len()) },
+                Level::Trace => unsafe { trace_message(bytes.as_ptr(), bytes.len()) },
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+#[no_mangle]
+extern "C" fn allocate_bytes(num_bytes: usize) -> *mut u8 {
+    let bytes = vec![0; num_bytes];
+    let mut byte_slice: Box<[u8]> = bytes.into_boxed_slice();
+    let ptr: *mut u8 = byte_slice.as_mut_ptr();
+    std::mem::forget(byte_slice);
+    ptr
+}
+
+#[no_mangle]
+unsafe extern "C" fn free_bytes(ptr: *mut u8, num_bytes: usize) {
+    let _bytes: Vec<u8> = Vec::from_raw_parts(ptr, num_bytes, num_bytes);
+}

--- a/static/gameboy.js
+++ b/static/gameboy.js
@@ -1,0 +1,272 @@
+var ctx;
+var imageData;
+var rustWasm;
+var emulatorPtr;
+var romBytes;
+var playerController = 0;
+var currentVolume = 100;
+var audioContext;
+// used to control master volume
+var gainNode;
+var channel1;
+var channel2;
+var channel3;
+var channel4;
+var channel5;
+
+const scale = 4;
+
+const buttons = {
+    A:      0,
+    B:      1,
+    START:  2,
+    SELECT: 3,
+    UP:     4,
+    DOWN:   5,
+    LEFT:   6,
+    RIGHT:  7,
+}
+
+async function initSound() {
+    audioContext = new window.AudioContext();
+    gainNode = audioContext.createGain();
+    channel1 = audioContext.createOscillator();
+    channel1.type = "square";
+    channel1.connect(gainNode);
+
+    channel2 = audioContext.createOscillator();
+    channel2.type = "square";
+    channel2.connect(gainNode);
+
+    channel3 = audioContext.createOscillator();
+    channel3.type = "triangle";
+    channel3.connect(gainNode);
+
+    gainNode.connect(audioContext.destination);
+}
+
+async function start() {
+    console.log("start");
+    const canvas = document.getElementById('canvas');
+    ctx = canvas.getContext('2d');
+    
+    ctx.fillStyle = 'green';
+    //ctx.scale(4, 4);
+    ctx.fillRect(10, 10, 150, 100);
+
+    imageData = ctx.createImageData(160 * scale, 144 * scale);
+
+    await loadWasm();
+}
+
+function draw_to_screen(ptr) {
+    let imageData = ctx.getImageData(0, 0, 160 * scale, 144 * scale);
+    let data = imageData.data;
+
+    const wasmMemory = new Uint8Array(rustWasm.instance.exports.memory.buffer);
+
+    for (let y = 0; y < 144; y++) {
+        for (let x = 0; x < 160; x++) {
+            const wasmIdx = ((y * 160) + x) * 3;
+            for (let x_scale = 0; x_scale < scale; x_scale++) {
+                for (let y_scale = 0; y_scale < scale; y_scale++) {
+                    let adj_x = x * scale + x_scale;
+                    let adj_y = y * scale + y_scale;
+                    const screenIdx = ((adj_y * 160 * scale) + adj_x) * 4;
+                    // RGB
+                    for (let i = 0; i < 3; i++) {
+                        data[screenIdx + i] = wasmMemory[ptr + wasmIdx + i];
+                    }
+                    data[screenIdx + 3] = 255;
+                }
+            }
+        }
+    }
+    ctx.putImageData(imageData, 0, 0);
+}
+
+function get_string_from_memory(ptr, len) {
+    const wasmMemory = new Uint8Array(rustWasm.instance.exports.memory.buffer);
+
+    // won't work on Internet explorer or older browsers
+    const decoder = new TextDecoder();
+    const str = decoder.decode(wasmMemory.slice(ptr, ptr + len));
+
+    return str;
+}
+
+function info_to_console(ptr, len) {
+    const str = get_string_from_memory(ptr, len);
+    console.info(str);
+}
+function warn_to_console(ptr, len) {
+    const str = get_string_from_memory(ptr, len);
+    console.info(str);
+}
+function error_to_console(ptr, len) {
+    const str = get_string_from_memory(ptr, len);
+    console.info(str);
+}
+function debug_to_console(ptr, len) {
+    const str = get_string_from_memory(ptr, len);
+    console.info(str);
+}
+function trace_to_console(ptr, len) {
+    const str = get_string_from_memory(ptr, len);
+    console.info(str);
+}
+
+const wasmInit = async (wasmModuleUrl, importObject) => {
+    console.log("wasmInit");
+
+  if (!importObject) {
+    importObject = {
+      env: {
+          draw_frame: (ptr) => draw_to_screen(ptr),
+          info_message: (ptr, len) => info_to_console(ptr, len),
+          error_message: (ptr, len) => error_to_console(ptr, len),
+          warn_message: (ptr, len) => warn_to_console(ptr, len),
+          debug_message: (ptr, len) => debug_to_console(ptr, len),
+          trace_message: (ptr, len) => trace_to_console(ptr, len),
+      }
+    };
+  }
+
+    const wasmArrayBuffer = await fetch(wasmModuleUrl).then(response =>
+        response.arrayBuffer()
+    );
+    return WebAssembly.instantiate(wasmArrayBuffer, importObject);
+};
+
+const loadWasm = async () => {
+    console.log("loadWasm");
+  rustWasm = await wasmInit("../target/wasm32-unknown-unknown/release/opt.wasm");
+  //rustWasm = await wasmInit("../target/wasm32-unknown-unknown/release/rusty_boy_lib.wasm");
+  //rustWasm = await wasmInit("../target/wasm32-unknown-unknown/debug/rusty_boy_lib.wasm");
+  //rustWasm.instance.exports.memory.grow(60000);
+    emulatorPtr = rustWasm.instance.exports.create_emulator();
+    if (!emulatorPtr) {
+        console.error("Failed to create emulator");
+        return;
+    }
+
+    const romBytesLen = romBytes.byteLength;
+    bytePtr = rustWasm.instance.exports.allocate_bytes(romBytesLen);
+    const wasmMemory = new Uint8Array(rustWasm.instance.exports.memory.buffer);
+
+    for (let i = 0; i < romBytesLen; i++) {
+        wasmMemory[bytePtr + i] = romBytes[i];
+    }
+    rustWasm.instance.exports.load_rom(emulatorPtr, bytePtr, romBytesLen);
+    rustWasm.instance.exports.free_bytes(bytePtr, romBytesLen);
+
+    window.requestAnimationFrame(runFrame);
+};
+
+const runFrame = () => {
+    rustWasm.instance.exports.step(emulatorPtr);
+    window.requestAnimationFrame(runFrame);
+};
+
+// TOOD: figure out wtf is going on with drag and drop...
+// https://stackoverflow.com/questions/8006715/drag-drop-files-into-standard-html-file-input
+// https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/File_drag_and_drop
+class dropHandler {
+};
+
+dropHandler.ondragover = dropHandler.ondragenter = function(evt) {
+    evt.preventDefault();
+};
+
+// handles dropping a file to load a ROM
+dropHandler.ondrop = function(ev) {
+    console.log('File(s) dropped');
+    
+    fileInput.files = evt.dataTransfer.files;
+    
+    // If you want to use some of the dropped files
+    const dT = new DataTransfer();
+    dT.items.add(evt.dataTransfer.files[0]);
+    dT.items.add(evt.dataTransfer.files[3]);
+    fileInput.files = dT.files;
+
+    // Prevent default behavior (Prevent file from being opened)
+    ev.preventDefault();
+}
+
+function handleKeyDown(e) {
+    const press = rustWasm.instance.exports.press_button;
+    if (e.keyCode == 37) {
+        press(emulatorPtr, buttons.LEFT, true);
+    } else if ( e.keyCode == 38) {
+        press(emulatorPtr, buttons.UP, true);
+    } else if ( e.keyCode == 39) {
+        press(emulatorPtr, buttons.RIGHT, true);
+    } else if ( e.keyCode == 40) {
+        press(emulatorPtr, buttons.DOWN, true);
+    } else if ( e.keyCode == 65) {
+        press(emulatorPtr, buttons.A, true);
+    } else if ( e.keyCode == 83) {
+        press(emulatorPtr, buttons.B, true);
+    } else if ( e.keyCode == 68 ) {
+        press(emulatorPtr, buttons.START, true);
+    } else if ( e.keyCode == 70 ) {
+        press(emulatorPtr, buttons.SELECT, true);
+    }
+}
+
+function handleKeyUp(e) {
+    const press = rustWasm.instance.exports.press_button;
+    if (e.keyCode == 37) {
+        press(emulatorPtr, buttons.LEFT, false);
+    } else if ( e.keyCode == 38) {
+        press(emulatorPtr, buttons.UP, false);
+    } else if ( e.keyCode == 39) {
+        press(emulatorPtr, buttons.RIGHT, false);
+    } else if ( e.keyCode == 40) {
+        press(emulatorPtr, buttons.DOWN, false);
+    } else if ( e.keyCode == 65) {
+        press(emulatorPtr, buttons.A, false);
+    } else if ( e.keyCode == 83) {
+        press(emulatorPtr, buttons.B, false);
+    } else if ( e.keyCode == 68 ) {
+        press(emulatorPtr, buttons.START, false);
+    } else if ( e.keyCode == 70 ) {
+        press(emulatorPtr, buttons.SELECT, false);
+    }
+}
+
+
+function setUpHandlers() {
+    // file handling
+    document.getElementById('fileInput').addEventListener('change', function() {
+        var reader = new FileReader();
+        reader.onload = function() {
+            romBytes = new Uint8Array(this.result);
+            console.log(romBytes);
+        }
+        reader.readAsArrayBuffer(this.files[0]);
+    }, false);
+
+    // TODO: add gamepad support
+    // https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/Using_the_Gamepad_API
+    window.addEventListener("gamepadconnected", function(e) {
+        console.log("Gamepad connected at index %d: %s. %d buttons, %d axes.",
+                    e.gamepad.index, e.gamepad.id,
+                    e.gamepad.buttons.length, e.gamepad.axes.length);
+    });
+
+    // user input support
+    //var canvas = document.getElementById('canvas')
+    // couldn't get it working on canvas directly... not sure why
+    window.addEventListener( 'keydown', handleKeyDown, true );
+    window.addEventListener( 'keyup', handleKeyUp, true );
+
+    initSound();
+
+    var volumeSlider = document.getElementById("volumeSlider");
+    volumeSlider.oninput = function() {
+        currentVolume = this.value;
+        gainNode.gain.setValueAtTime(currentVolume / 100.0, audioContext.currentTime);
+    };
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>Rusty Boy</title>
+    <script src="gameboy.js"></script>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body onload="setUpHandlers()"> <!-- onload="start()"> -->
+    <!-- TODO: use `ondragover` event for UX too-->
+    <div id="dropHandler">
+      <canvas id="canvas" width=640 height=576 style="border:1px solid #000000;"></canvas>
+      <button onclick="start()" type="button">Start</button>
+      <input type="file" id="fileInput" />
+      <div class="slidecontainer">
+        <label for="volumeSlider">Volume</label>
+        <input type="range" min="0" max="100" value="100" class="slider" id="volumeSlider">
+      </div>
+    </div>
+  </body>
+</html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,4 @@
+canvas {
+    image-rendering: pixelated;
+  }
+  


### PR DESCRIPTION
Need to add some tests in CI and then make a CD flow to distribute new Wasm binaries to a github pages site automatically.

I noticed some major performance problems and looked around a bit and there are lots of likely culprits. Some of the memory logging stuff was always on and was super expensive due to logging every jump, return, memory read/write. A general pass for performance is definitely in order. There's no need for any complicated optimizations as the gameboy is very simple, we just need to stop doing excessively slow things for no reason and performance will be great.